### PR TITLE
메인페이지 프로젝트 조회 스킬태그 필터링 오류 수정

### DIFF
--- a/src/main/java/hs/kr/backend/devpals/domain/project/controller/ProjectController.java
+++ b/src/main/java/hs/kr/backend/devpals/domain/project/controller/ProjectController.java
@@ -35,7 +35,7 @@ public class ProjectController {
             )
     )
     public ResponseEntity<ApiResponse<ProjectListResponse>> getProjectAll(
-            @RequestParam(required = false, defaultValue = "[]") List<Long> skillTag,
+            @RequestParam(required = false, defaultValue = "") List<Long> skillTag,
             @RequestParam(defaultValue = "0") Long positionTag,
             @RequestParam(defaultValue = "0") Long methodType,
             @RequestParam(defaultValue = "false") Boolean isBeginner,

--- a/src/main/java/hs/kr/backend/devpals/domain/project/controller/ProjectController.java
+++ b/src/main/java/hs/kr/backend/devpals/domain/project/controller/ProjectController.java
@@ -35,7 +35,7 @@ public class ProjectController {
             )
     )
     public ResponseEntity<ApiResponse<ProjectListResponse>> getProjectAll(
-            @RequestParam(required = false, defaultValue = "") List<Long> skillTag,
+            @RequestParam(required = false, defaultValue = "[]") List<Long> skillTag,
             @RequestParam(defaultValue = "0") Long positionTag,
             @RequestParam(defaultValue = "0") Long methodType,
             @RequestParam(defaultValue = "false") Boolean isBeginner,

--- a/src/main/java/hs/kr/backend/devpals/domain/project/dto/ProjectAllDto.java
+++ b/src/main/java/hs/kr/backend/devpals/domain/project/dto/ProjectAllDto.java
@@ -94,6 +94,7 @@ public class ProjectAllDto {
                 .isDone(project.isDone())
                 .recruitmentStartDate(project.getRecruitmentStartDate())
                 .recruitmentEndDate(project.getRecruitmentEndDate())
+                .skillTagIds(project.getSkillTagIds() != null ? project.getSkillTagIds() : List.of())
                 .user(user)
                 .methodType(methodType)
                 .positions(positions)


### PR DESCRIPTION
메인페이지 프로젝트 조회 필터링 과정에서 스킬태그에 숫자를 입력하면 값을 가져오지 못하는 현상이 발견돼 수정하였습니다.