### PR TITLE
[Feat] 내가 작성한 댓글, 문의글 조회 기능 구현

### DIFF
--- a/src/main/java/hs/kr/backend/devpals/domain/Inquiry/dto/InquiryDto.java
+++ b/src/main/java/hs/kr/backend/devpals/domain/Inquiry/dto/InquiryDto.java
@@ -1,6 +1,8 @@
 package hs.kr.backend.devpals.domain.Inquiry.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import hs.kr.backend.devpals.domain.Inquiry.entity.InquiryEntity;
+import hs.kr.backend.devpals.domain.Inquiry.entity.InquiryImageEntity;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -29,11 +31,16 @@ public class InquiryDto {
     @Schema(description = "등록된 이미지 URL 목록", example = "[\"https://devpal.s3.ap-northeast-2.amazonaws.com/devpals_inquiry1-1-1.png\", \"https://...\"]")
     private List<String> imageUrls;
 
-    public static InquiryDto fromEntity(List<String> imageUrls, String title, String content, String category) {
+    public static InquiryDto fromEntity(InquiryEntity inquiry) {
+        List<String> imageUrls = inquiry.getImages()
+                .stream()
+                .map(InquiryImageEntity::getImageUrl)
+                .toList();
+
         return InquiryDto.builder()
-                .title(title)
-                .content(content)
-                .category(category)
+                .title(inquiry.getTitle())
+                .content(inquiry.getContent())
+                .category(inquiry.getCategory())
                 .imageUrls(imageUrls)
                 .build();
     }

--- a/src/main/java/hs/kr/backend/devpals/domain/Inquiry/repository/InquiryRepository.java
+++ b/src/main/java/hs/kr/backend/devpals/domain/Inquiry/repository/InquiryRepository.java
@@ -3,6 +3,9 @@ package hs.kr.backend.devpals.domain.Inquiry.repository;
 import hs.kr.backend.devpals.domain.Inquiry.entity.InquiryEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface InquiryRepository extends JpaRepository<InquiryEntity, Long> {
     int countByUserId(Long userId);
+    List<InquiryEntity> findByUserId(Long userId);
 }

--- a/src/main/java/hs/kr/backend/devpals/domain/Inquiry/service/InquiryService.java
+++ b/src/main/java/hs/kr/backend/devpals/domain/Inquiry/service/InquiryService.java
@@ -74,12 +74,7 @@ public class InquiryService {
                 .map(InquiryImageEntity::getImageUrl)
                 .toList();
 
-        InquiryDto response = InquiryDto.fromEntity(
-                imageUrls,
-                inquiry.getTitle(),
-                inquiry.getContent(),
-                inquiry.getCategory()
-        );
+        InquiryDto response = InquiryDto.fromEntity(inquiry);
 
         return ResponseEntity.ok(new ApiResponse<>(true, "문의 조회 성공", response));
     }

--- a/src/main/java/hs/kr/backend/devpals/domain/project/repository/CommentRepoisitory.java
+++ b/src/main/java/hs/kr/backend/devpals/domain/project/repository/CommentRepoisitory.java
@@ -7,4 +7,5 @@ import java.util.List;
 
 public interface CommentRepoisitory extends JpaRepository<CommentEntity, Long> {
     List<CommentEntity> findAllByProjectId(Long projectId);
+    List<CommentEntity> findByUserId(Long userId);
 }

--- a/src/main/java/hs/kr/backend/devpals/domain/user/controller/UserProfileController.java
+++ b/src/main/java/hs/kr/backend/devpals/domain/user/controller/UserProfileController.java
@@ -1,5 +1,6 @@
 package hs.kr.backend.devpals.domain.user.controller;
 
+import hs.kr.backend.devpals.domain.user.dto.CommentInquiryDto;
 import hs.kr.backend.devpals.domain.user.dto.UserResponse;
 import hs.kr.backend.devpals.domain.user.dto.UserUpdateRequest;
 import hs.kr.backend.devpals.domain.user.service.UserProfileService;
@@ -109,5 +110,22 @@ public class UserProfileController {
             @RequestHeader("Authorization") String token,
             @RequestParam String nickname){
         return userProfileService.userNicknameCheck(token, nickname);
+    }
+
+    @GetMapping("/my-activities")
+    @Operation(summary = "내 활동 조회", description = "본인이 작성한 댓글 및 문의글 목록을 조회합니다.")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "댓글 및 문의글 조회 성공")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "400",
+            description = "댓글 및 문의글 조회 실패",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ApiResponse.class),
+                    examples = @ExampleObject(value = "{\"success\": false, \"message\": \"인증 권한이 없습니다.\", \"data\": null}")
+            )
+    )
+    public ResponseEntity<ApiResponse<CommentInquiryDto>> getMyActivities(
+            @RequestHeader("Authorization") String token) {
+        return userProfileService.getMyCommentInquiry(token);
     }
 }

--- a/src/main/java/hs/kr/backend/devpals/domain/user/dto/CommentInquiryDto.java
+++ b/src/main/java/hs/kr/backend/devpals/domain/user/dto/CommentInquiryDto.java
@@ -1,0 +1,23 @@
+package hs.kr.backend.devpals.domain.user.dto;
+
+import hs.kr.backend.devpals.domain.Inquiry.dto.InquiryDto;
+import hs.kr.backend.devpals.domain.project.dto.CommentDTO;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class CommentInquiryDto {
+
+    private List<CommentDTO> comments;
+    private List<InquiryDto> inquiries;
+
+    public static CommentInquiryDto of(List<CommentDTO> comments, List<InquiryDto> inquiries) {
+        return CommentInquiryDto.builder()
+                .comments(comments)
+                .inquiries(inquiries)
+                .build();
+    }
+}

--- a/src/main/java/hs/kr/backend/devpals/domain/user/service/UserProfileService.java
+++ b/src/main/java/hs/kr/backend/devpals/domain/user/service/UserProfileService.java
@@ -1,6 +1,14 @@
 package hs.kr.backend.devpals.domain.user.service;
 
+import hs.kr.backend.devpals.domain.Inquiry.dto.InquiryDto;
+import hs.kr.backend.devpals.domain.Inquiry.entity.InquiryEntity;
+import hs.kr.backend.devpals.domain.Inquiry.repository.InquiryRepository;
+import hs.kr.backend.devpals.domain.project.dto.CommentDTO;
+import hs.kr.backend.devpals.domain.project.entity.CommentEntity;
+import hs.kr.backend.devpals.domain.project.repository.CommentRepoisitory;
+import hs.kr.backend.devpals.domain.project.repository.RecommentRepository;
 import hs.kr.backend.devpals.domain.project.service.ProjectService;
+import hs.kr.backend.devpals.domain.user.dto.CommentInquiryDto;
 import hs.kr.backend.devpals.domain.user.dto.UserResponse;
 import hs.kr.backend.devpals.domain.user.dto.UserUpdateRequest;
 import hs.kr.backend.devpals.domain.user.entity.UserEntity;
@@ -18,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -25,6 +34,9 @@ public class UserProfileService {
 
     private final UserFacade userFacade;
     private final UserRepository userRepository;
+    private final CommentRepoisitory commentRepository;
+    private final RecommentRepository recommentRepository;
+    private final InquiryRepository inquiryRepository;
     private final JwtTokenValidator jwtTokenValidator;
     private final AwsS3Client awsS3Client;
     private final ProjectService projectService;
@@ -138,6 +150,32 @@ public class UserProfileService {
         userRepository.save(user);
 
         return ResponseEntity.ok(new ApiResponse<>(true, "프로필 이미지가 변경되었습니다.", fileUrl));
+    }
+
+    @Transactional(readOnly = true)
+    public ResponseEntity<ApiResponse<CommentInquiryDto>> getMyCommentInquiry(String token) {
+        Long userId = jwtTokenValidator.getUserId(token);
+
+        // 댓글 조회
+        List<CommentEntity> comments = commentRepository.findByUserId(userId);
+
+        List<CommentDTO> commentDTOs = comments.stream()
+                .map(comment -> {
+                    int recommentCount = recommentRepository.countByCommentId(comment.getId());
+                    return CommentDTO.fromEntity(comment, recommentCount);
+                })
+                .collect(Collectors.toList());
+
+        // 문의글 조회
+        List<InquiryEntity> inquiries = inquiryRepository.findByUserId(userId);
+        List<InquiryDto> inquiryDTOs = inquiries.stream()
+                .map(InquiryDto::fromEntity)
+                .collect(Collectors.toList());
+
+        // 응답 만들기
+        CommentInquiryDto response = CommentInquiryDto.of(commentDTOs, inquiryDTOs);
+
+        return ResponseEntity.ok(new ApiResponse<>(true, "작성한 댓글 및 문의글 목록입니다.", response));
     }
 
 }


### PR DESCRIPTION
본인이 작성했던 댓글 , 문의글들을 조회할 수 있는 기능을 구현했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 사용자가 자신의 댓글과 문의글 목록을 조회할 수 있는 새로운 API 엔드포인트(`/user/my-activities`)가 추가되었습니다.
  - 댓글과 문의글 정보를 함께 포함하는 새로운 데이터 전송 객체(DTO)가 도입되었습니다.

- **버그 수정**
  - 해당 없음.

- **리팩터링**
  - 문의글 DTO 생성 방식이 간소화되어, 엔티티에서 직접 필요한 정보를 추출하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->