### PR TITLE
Dev > Main 브랜치 병합

### DIFF
--- a/src/main/java/hs/kr/backend/devpals/infra/oauth2/CustomOauth2UserService.java
+++ b/src/main/java/hs/kr/backend/devpals/infra/oauth2/CustomOauth2UserService.java
@@ -2,20 +2,24 @@ package hs.kr.backend.devpals.infra.oauth2;
 
 import hs.kr.backend.devpals.domain.user.entity.UserEntity;
 import hs.kr.backend.devpals.domain.user.repository.UserRepository;
+import hs.kr.backend.devpals.global.exception.CustomException;
+import hs.kr.backend.devpals.global.exception.ErrorException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.*;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -26,7 +30,7 @@ public class CustomOauth2UserService extends DefaultOAuth2UserService {
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) {
         OAuth2User oAuth2User = super.loadUser(userRequest);
-        String provider = userRequest.getClientRegistration().getRegistrationId(); // github, github-auth, google, etc.
+        String provider = userRequest.getClientRegistration().getRegistrationId();
 
         // 요청에 provider 저장
         ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
@@ -35,14 +39,13 @@ public class CustomOauth2UserService extends DefaultOAuth2UserService {
             request.setAttribute("provider", provider);
         }
 
-        String email = extractEmail(provider, oAuth2User);
+        String email = extractEmail(provider, oAuth2User, userRequest);
         String name = extractName(provider, oAuth2User);
 
         if (email == null) {
             throw new IllegalArgumentException("소셜 로그인 응답에서 email을 찾을 수 없습니다.");
         }
 
-        // github-auth는 기존 유저의 인증만 처리하므로 user 저장은 생략
         if (!"github-auth".equals(provider)) {
             UserEntity user = userRepository.findByEmail(email)
                     .orElseGet(() -> new UserEntity(email, "SOCIAL_LOGIN_USER", name, true));
@@ -52,11 +55,15 @@ public class CustomOauth2UserService extends DefaultOAuth2UserService {
                 user.updateGithub(githubUrl);
             }
 
-            userRepository.save(user);
+            try {
+                userRepository.save(user);
+            } catch (DataIntegrityViolationException e) {
+                throw new CustomException(ErrorException.DUPLICATE_NICKNAME);
+            }
         }
 
         Map<String, Object> attributesMap = new HashMap<>(oAuth2User.getAttributes());
-        attributesMap.put("email", email);
+        attributesMap.put("email", email); // email 보장
 
         return new DefaultOAuth2User(
                 Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")),
@@ -65,7 +72,7 @@ public class CustomOauth2UserService extends DefaultOAuth2UserService {
         );
     }
 
-    public static String extractEmail(String provider, OAuth2User oAuth2User) {
+    public static String extractEmail(String provider, OAuth2User oAuth2User, OAuth2UserRequest userRequest) {
         switch (provider) {
             case "google":
                 return oAuth2User.getAttribute("email");
@@ -76,9 +83,12 @@ public class CustomOauth2UserService extends DefaultOAuth2UserService {
                 Map<String, Object> response = oAuth2User.getAttribute("response");
                 return response != null ? (String) response.get("email") : null;
             case "github":
-                return oAuth2User.getAttribute("email");
             case "github-auth":
-                return oAuth2User.getAttribute("email");
+                String email = oAuth2User.getAttribute("email");
+                if (email == null) {
+                    email = fetchPrimaryEmailFromGithub(userRequest);
+                }
+                return email;
             default:
                 throw new IllegalArgumentException("Unsupported provider: " + provider);
         }
@@ -97,11 +107,33 @@ public class CustomOauth2UserService extends DefaultOAuth2UserService {
                 Map<String, Object> response = oAuth2User.getAttribute("response");
                 return response != null ? (String) response.get("name") : null;
             case "github":
-                return oAuth2User.getAttribute("email");
             case "github-auth":
                 return oAuth2User.getAttribute("name");
             default:
                 throw new IllegalArgumentException("Unsupported provider: " + provider);
         }
+    }
+
+    private static String fetchPrimaryEmailFromGithub(OAuth2UserRequest userRequest) {
+        String token = userRequest.getAccessToken().getTokenValue();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(token);
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+        HttpEntity<Void> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<List<Map<String, Object>>> response = new RestTemplate()
+                .exchange(
+                        "https://api.github.com/user/emails",
+                        HttpMethod.GET,
+                        entity,
+                        new ParameterizedTypeReference<>() {}
+                );
+
+        return response.getBody().stream()
+                .filter(e -> Boolean.TRUE.equals(e.get("primary")) && Boolean.TRUE.equals(e.get("verified")))
+                .map(e -> (String) e.get("email"))
+                .findFirst()
+                .orElse(null);
     }
 }

--- a/src/main/java/hs/kr/backend/devpals/infra/oauth2/Oauth2LoginSuccessHandler.java
+++ b/src/main/java/hs/kr/backend/devpals/infra/oauth2/Oauth2LoginSuccessHandler.java
@@ -25,24 +25,21 @@ public class Oauth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
                                         Authentication authentication) throws IOException {
+
         OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+        String email = (String) oAuth2User.getAttributes().get("email");
         String provider = (String) request.getAttribute("provider");
 
-        if (provider == null) {
-            provider = oAuth2User.getAttributes().containsKey("kakao_account") ? "kakao" :
-                    oAuth2User.getAttributes().containsKey("response") ? "naver" :
-                            oAuth2User.getAttributes().containsKey("login") ? "github" : "google";
-        }
-
-        String email = CustomOauth2UserService.extractEmail(provider, oAuth2User);
         if (email == null) {
             throw new CustomException(ErrorException.USER_NOT_FOUND);
         }
 
         if ("github-auth".equals(provider)) {
             String githubUrl = oAuth2User.getAttribute("html_url");
+
             UserEntity user = userRepository.findByEmail(email)
                     .orElseThrow(() -> new CustomException(ErrorException.USER_NOT_FOUND));
+
             user.updateGithub(githubUrl);
             userRepository.save(user);
 


### PR DESCRIPTION
1. Oauth github email null 로 나오는 오류를 수정 후 테스트를 위해 Main 브랜치로 병합합니다.
2. 닉네임 중복 에러처리 로직을 작성 후 확인을 위해 Main 브랜치로 병합합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- GitHub OAuth2 로그인 시 이메일 정보가 누락된 경우, GitHub API를 통해 기본 이메일을 정확히 가져오도록 개선되었습니다.
	- OAuth2 로그인 중 중복 닉네임 발생 시, 명확한 오류 메시지가 제공됩니다.

- **기타**
	- OAuth2 로그인 성공 처리 로직이 간소화되어 안정성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->