### PR TITLE
Dev > Main 브랜치 병합

### DIFF
--- a/src/main/java/hs/kr/backend/devpals/domain/user/controller/UserAdminController.java
+++ b/src/main/java/hs/kr/backend/devpals/domain/user/controller/UserAdminController.java
@@ -1,0 +1,57 @@
+package hs.kr.backend.devpals.domain.user.controller;
+
+import hs.kr.backend.devpals.domain.user.dto.AdminUserResponse;
+import hs.kr.backend.devpals.domain.user.dto.UserAdminPreviewResponse;
+import hs.kr.backend.devpals.domain.user.service.UserAdminService;
+import hs.kr.backend.devpals.global.common.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/users")
+@RequiredArgsConstructor
+public class UserAdminController {
+
+    private UserAdminService userAdminService;
+
+    @GetMapping("/preview")
+    @Operation(summary = "회원 전체 미리보기", description = "관리자용 전체 회원 미리보기를 조회합니다.")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "회원 미리보기 조회 성공")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "400",
+            description = "회원 미리보기 조회 실패",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ApiResponse.class),
+                    examples = @ExampleObject(value = "{\"success\": false, \"message\": \"유저 정보를 조회할 수 없습니다.\", \"data\": null}")
+            )
+    )
+    public ResponseEntity<ApiResponse<List<UserAdminPreviewResponse>>> getAllUsersPreview() {
+        return userAdminService.getAllUsersPreview();
+    }
+
+    @GetMapping
+    @Operation(summary = "회원 전체 상세 조회", description = "관리자용 전체 회원 정보를 상세히 조회합니다.")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "유저 정보 조회 성공")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "400",
+            description = "유저 정보 조회 실패",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ApiResponse.class),
+                    examples = @ExampleObject(value = "{\"success\": false, \"message\": \"유저 정보를 조회할 수 없습니다.\", \"data\": null}")
+            )
+    )
+    public ResponseEntity<ApiResponse<List<AdminUserResponse>>> getAllUsersDetail() {
+        return userAdminService.getAllUsersDetail();
+    }
+}

--- a/src/main/java/hs/kr/backend/devpals/domain/user/dto/AdminUserResponse.java
+++ b/src/main/java/hs/kr/backend/devpals/domain/user/dto/AdminUserResponse.java
@@ -1,0 +1,53 @@
+package hs.kr.backend.devpals.domain.user.dto;
+
+import hs.kr.backend.devpals.domain.tag.dto.PositionTagResponse;
+import hs.kr.backend.devpals.domain.tag.dto.SkillTagResponse;
+import hs.kr.backend.devpals.domain.tag.service.TagService;
+import hs.kr.backend.devpals.domain.user.entity.UserEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class AdminUserResponse {
+    private Long id;
+    private String nickname;
+    private String email;
+    private String profileImg;
+    private Integer warning;
+    private List<PositionTagResponse> positions;
+    private List<SkillTagResponse> skills;
+    private LocalDateTime createdAt;
+
+
+    public static AdminUserResponse fromEntity(UserEntity user, TagService tagService) {
+        List<Long> positionIds = Optional.ofNullable(user.getPositionIds()).orElse(List.of());
+        List<Long> skillIds = Optional.ofNullable(user.getSkillIds()).orElse(List.of());
+
+        List<PositionTagResponse> positionResponses = tagService.getPositionTagByIds(positionIds).stream()
+                .map(PositionTagResponse::fromEntity)
+                .collect(Collectors.toList());
+
+        List<SkillTagResponse> skillResponses = tagService.getSkillTagsByIds(skillIds).stream()
+                .map(SkillTagResponse::fromEntity)
+                .collect(Collectors.toList());
+
+        return AdminUserResponse.builder()
+                .id(user.getId())
+                .nickname(user.getNickname())
+                .email(user.getEmail())
+                .profileImg(user.getProfileImg())
+                .warning(user.getWarning())
+                .positions(positionResponses)
+                .skills(skillResponses)
+                .createdAt(user.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/hs/kr/backend/devpals/domain/user/dto/UserAdminPreviewResponse.java
+++ b/src/main/java/hs/kr/backend/devpals/domain/user/dto/UserAdminPreviewResponse.java
@@ -1,0 +1,28 @@
+package hs.kr.backend.devpals.domain.user.dto;
+
+import hs.kr.backend.devpals.domain.user.entity.UserEntity;
+import lombok.Builder;
+import lombok.Getter;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class UserAdminPreviewResponse {
+
+    private Long id;
+    private String nickname;
+    private String email;
+    private String profileImg;
+    // private Boolean isOnline;
+    private LocalDateTime createdAt;
+
+    public static UserAdminPreviewResponse from(UserEntity user) {
+        return UserAdminPreviewResponse.builder()
+                .id(user.getId())
+                .nickname(user.getNickname())
+                .email(user.getEmail())
+                .profileImg(user.getProfileImg())
+                .createdAt(user.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/hs/kr/backend/devpals/domain/user/service/UserAdminService.java
+++ b/src/main/java/hs/kr/backend/devpals/domain/user/service/UserAdminService.java
@@ -1,0 +1,44 @@
+package hs.kr.backend.devpals.domain.user.service;
+
+import hs.kr.backend.devpals.domain.tag.service.TagService;
+import hs.kr.backend.devpals.domain.user.dto.AdminUserResponse;
+import hs.kr.backend.devpals.domain.user.entity.UserEntity;
+import hs.kr.backend.devpals.domain.user.repository.UserRepository;
+import hs.kr.backend.devpals.global.common.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import hs.kr.backend.devpals.domain.user.dto.UserAdminPreviewResponse;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class UserAdminService {
+
+    private final UserRepository userRepository;
+    private final TagService tagService;
+
+
+    public ResponseEntity<ApiResponse<List<UserAdminPreviewResponse>>> getAllUsersPreview() {
+        List<UserEntity> users = userRepository.findAll();
+
+        //boolean isOnline = userSessionManager.isOnline(user.getId());
+        List<UserAdminPreviewResponse> result = users.stream()
+                .map(UserAdminPreviewResponse::from)
+                .toList();
+
+        return ResponseEntity.ok(new ApiResponse<>(200, true, "회원 미리보기 조회 성공", result));
+    }
+
+    public ResponseEntity<ApiResponse<List<AdminUserResponse>>> getAllUsersDetail() {
+        List<UserEntity> users = userRepository.findAll();
+
+        List<AdminUserResponse> result = users.stream()
+                .map(user -> AdminUserResponse.fromEntity(user, tagService))
+                .toList();
+
+        return ResponseEntity.ok(new ApiResponse<>(200, true, "회원 전체 상세 조회 성공", result));
+    }
+}


### PR DESCRIPTION
1. 관리자 유저 미리보기, 상세 조회 기능 구현 후 통합테스트 거친 뒤 Main 브랜치로 병합합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 관리자를 위한 전체 사용자 미리보기 및 상세 정보 조회 API 엔드포인트가 추가되었습니다.
    - 사용자 미리보기 및 상세 정보를 위한 새로운 응답 형식이 도입되었습니다.
    - 관리자는 사용자 목록을 간편하게 확인하고, 각 사용자의 태그 및 경고 횟수 등 상세 정보를 조회할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->