### PR TITLE
Dev > Main 브랜치 병합

### DIFF
--- a/src/main/java/hs/kr/backend/devpals/domain/tag/controller/TagController.java
+++ b/src/main/java/hs/kr/backend/devpals/domain/tag/controller/TagController.java
@@ -1,12 +1,15 @@
 package hs.kr.backend.devpals.domain.tag.controller;
 
 import hs.kr.backend.devpals.domain.tag.dto.PositionTagRequest;
+import hs.kr.backend.devpals.domain.tag.dto.PositionTagResponse;
 import hs.kr.backend.devpals.domain.tag.dto.SkillTagRequest;
+import hs.kr.backend.devpals.domain.tag.dto.SkillTagResponse;
 import hs.kr.backend.devpals.domain.tag.entity.PositionTagEntity;
 import hs.kr.backend.devpals.domain.tag.entity.SkillTagEntity;
 import hs.kr.backend.devpals.domain.tag.service.TagService;
 import hs.kr.backend.devpals.global.common.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -70,7 +73,7 @@ public class TagController {
                     examples = @ExampleObject(value = "{\"success\": false, \"message\": \"포지션 태그를 저장하던 중 오류가 발생했습니다.\", \"data\": null}")
             )
     )
-    public ResponseEntity<ApiResponse<PositionTagEntity>> createPositionTag(@RequestBody PositionTagRequest request) {
+    public ResponseEntity<ApiResponse<PositionTagResponse>> createPositionTag(@RequestBody PositionTagRequest request) {
         return tagService.createPositionTag(request);
     }
 
@@ -97,11 +100,11 @@ public class TagController {
                     )
             }
     )
-    public ResponseEntity<ApiResponse<SkillTagEntity>> createSkillTag(@ModelAttribute SkillTagRequest request) {
+    public ResponseEntity<ApiResponse<SkillTagResponse>> createSkillTag(@ModelAttribute SkillTagRequest request) {
         return tagService.createSkillTag(request);
     }
 
-    @DeleteMapping("/position-tag")
+    @DeleteMapping("/position-tag/{positionTagId}")
     @Operation(summary = "포지션 태그 삭제", description = "포지션 태그를 삭제합니다.")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "포지션 태그 삭제 성공")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -113,11 +116,11 @@ public class TagController {
                     examples = @ExampleObject(value = "{\"success\": false, \"message\": \"포지션 태그를 삭제하던 중 오류가 발생했습니다.\", \"data\": null}")
             )
     )
-    public ResponseEntity<ApiResponse<String>> deletePositionTag(@RequestParam Long positionTagId) {
+    public ResponseEntity<ApiResponse<String>> deletePositionTag(@PathVariable Long positionTagId) {
         return tagService.deletePositionTag(positionTagId);
     }
 
-    @DeleteMapping("/skill-tag")
+    @DeleteMapping("/skill-tag/{skillTagId}")
     @Operation(summary = "스킬 태그 삭제", description = "스킬 태그를 삭제합니다.")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "스킬 태그 삭제 성공")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -129,7 +132,37 @@ public class TagController {
                     examples = @ExampleObject(value = "{\"success\": false, \"message\": \"스킬 태그를 삭제하던 중 오류가 발생했습니다.\", \"data\": null}")
             )
     )
-    public ResponseEntity<ApiResponse<String>> deleteSkillTag(@RequestParam Long skillTagId) {
+    public ResponseEntity<ApiResponse<String>> deleteSkillTag(@PathVariable Long skillTagId) {
         return tagService.deleteSkillTag(skillTagId);
+    }
+
+    @PutMapping("/skill-tag/{skillTagId}")
+    @Operation(
+            summary = "스킬 태그 수정",
+            description = "기존 스킬 태그의 이름과 이미지를 수정합니다.",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "수정 성공"),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "스킬 태그를 찾을 수 없음")
+            }
+    )
+    public ResponseEntity<ApiResponse<SkillTagResponse>> updateSkillTag(
+            @Parameter(description = "수정할 스킬 태그 ID", example = "1") @PathVariable Long skillTagId,
+            @ModelAttribute SkillTagRequest request) {
+        return tagService.updateSkillTag(skillTagId, request);
+    }
+
+    @PutMapping("/position-tag/{positionTagId}")
+    @Operation(
+            summary = "포지션 태그 수정",
+            description = "기존 포지션 태그의 이름을 수정합니다.",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "수정 성공"),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "포지션 태그를 찾을 수 없음")
+            }
+    )
+    public ResponseEntity<ApiResponse<PositionTagResponse>> updatePositionTag(
+            @Parameter(description = "수정할 포지션 태그 ID", example = "1") @PathVariable Long positionTagId,
+            @RequestBody PositionTagRequest request) {
+        return tagService.updatePositionTag(positionTagId, request);
     }
 }

--- a/src/main/java/hs/kr/backend/devpals/domain/tag/entity/PositionTagEntity.java
+++ b/src/main/java/hs/kr/backend/devpals/domain/tag/entity/PositionTagEntity.java
@@ -24,4 +24,8 @@ public class PositionTagEntity {
     public PositionTagEntity(String name) {
         this.name = name;
     }
+
+    public void update(String name) {
+        this.name = name;
+    }
 }

--- a/src/main/java/hs/kr/backend/devpals/domain/tag/entity/SkillTagEntity.java
+++ b/src/main/java/hs/kr/backend/devpals/domain/tag/entity/SkillTagEntity.java
@@ -30,4 +30,10 @@ public class SkillTagEntity {
         this.img = img;
     }
 
+    public void update(String name, String imgUrl) {
+        this.name = name;
+        if (imgUrl != null) {
+            this.img = imgUrl;
+        }
+    }
 }


### PR DESCRIPTION
1. 스킬 , 포지션 태그 삭제 RequestParam에서 PathVariable로 수정하였습니다.
2. 스킬 , 포지션 태그 수정 기능을 구현하였습니다.

통합테스트 거친 뒤 Main 브랜치로 병합합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- 기존 스킬 태그 및 포지션 태그를 수정할 수 있는 엔드포인트가 추가되었습니다.
- **API 변경**
	- 스킬 태그 및 포지션 태그 생성 시 반환값이 엔티티에서 응답 DTO로 변경되었습니다.
	- 삭제 엔드포인트가 쿼리 파라미터에서 URL 경로 변수로 변경되었습니다.
	- Swagger 문서가 최신 API 변경사항을 반영하여 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->