### PR TITLE
Dev > Main 브랜치 병합

### DIFF
--- a/src/main/java/hs/kr/backend/devpals/domain/project/controller/ProjectAdminController.java
+++ b/src/main/java/hs/kr/backend/devpals/domain/project/controller/ProjectAdminController.java
@@ -1,0 +1,35 @@
+package hs.kr.backend.devpals.domain.project.controller;
+
+import hs.kr.backend.devpals.domain.project.dto.FullApplicantInfoResponse;
+import hs.kr.backend.devpals.domain.project.service.ProjectAdminService;
+import hs.kr.backend.devpals.global.common.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/admin/project")
+@Tag(name = "Admin Project API", description = "관리자 전용 프로젝트 관련 API")
+@RequiredArgsConstructor
+public class ProjectAdminController {
+    private final ProjectAdminService projectAdminService;
+
+    @GetMapping("/{projectId}/full")
+    @Operation(
+            summary = "프로젝트 지원 정보 전체 조회 (관리자 전용)",
+            description = "해당 프로젝트의 전체 지원자 목록, 특정 지원자의 상세 정보, 합불 결과를 한번에 조회합니다.",
+            parameters = {
+                    @Parameter(name = "projectId", description = "조회할 프로젝트 ID", example = "1"),
+                    @Parameter(name = "applicantId", description = "상세 정보를 볼 지원자 ID", example = "5")
+            }
+    )
+    public ResponseEntity<ApiResponse<FullApplicantInfoResponse>> getFullApplicants(
+            @PathVariable Long projectId,
+            @RequestParam Long applicantId,
+            @RequestHeader("Authorization") String token) {
+        return projectAdminService.getFullApplicantInfo(projectId, applicantId, token);
+    }
+}

--- a/src/main/java/hs/kr/backend/devpals/domain/project/controller/ProjectApplyController.java
+++ b/src/main/java/hs/kr/backend/devpals/domain/project/controller/ProjectApplyController.java
@@ -1,7 +1,7 @@
 package hs.kr.backend.devpals.domain.project.controller;
 
 import hs.kr.backend.devpals.domain.project.dto.*;
-import hs.kr.backend.devpals.domain.project.service.ApplyService;
+import hs.kr.backend.devpals.domain.project.service.ProjectApplyService;
 import hs.kr.backend.devpals.global.common.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -18,9 +18,9 @@ import java.util.List;
 @RequestMapping("/project")
 @RequiredArgsConstructor
 @Tag(name = "Project Apply API", description = "프로젝트 지원 관련 API")
-public class ApplyController {
+public class ProjectApplyController {
 
-    private final ApplyService applicantService;
+    private final ProjectApplyService applicantService;
 
     @PostMapping("/{projectId}/apply")
     @Operation(summary = "프로젝트 지원", description = "프로젝트를 지원합니다.")

--- a/src/main/java/hs/kr/backend/devpals/domain/project/dto/FullApplicantInfoResponse.java
+++ b/src/main/java/hs/kr/backend/devpals/domain/project/dto/FullApplicantInfoResponse.java
@@ -1,0 +1,29 @@
+package hs.kr.backend.devpals.domain.project.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FullApplicantInfoResponse {
+
+    private List<ProjectApplicantResponse> applicants;
+    private ProjectApplyDTO detail;
+    private List<ProjectApplicantResultResponse> results;
+
+    public static FullApplicantInfoResponse From(List<ProjectApplicantResponse> applicants,
+                                                      ProjectApplyDTO detail,
+                                                      List<ProjectApplicantResultResponse> results) {
+        return FullApplicantInfoResponse.builder()
+                .applicants(applicants)
+                .detail(detail)
+                .results(results)
+                .build();
+    }
+}

--- a/src/main/java/hs/kr/backend/devpals/domain/project/service/ProjectAdminService.java
+++ b/src/main/java/hs/kr/backend/devpals/domain/project/service/ProjectAdminService.java
@@ -1,0 +1,68 @@
+package hs.kr.backend.devpals.domain.project.service;
+
+import hs.kr.backend.devpals.domain.faq.service.FaqAdminService;
+import hs.kr.backend.devpals.domain.project.dto.FullApplicantInfoResponse;
+import hs.kr.backend.devpals.domain.project.dto.ProjectApplicantResponse;
+import hs.kr.backend.devpals.domain.project.dto.ProjectApplicantResultResponse;
+import hs.kr.backend.devpals.domain.project.dto.ProjectApplyDTO;
+import hs.kr.backend.devpals.domain.project.entity.ApplicantEntity;
+import hs.kr.backend.devpals.domain.project.entity.ProjectEntity;
+import hs.kr.backend.devpals.domain.project.repository.ApplicantRepository;
+import hs.kr.backend.devpals.domain.project.repository.ProjectRepository;
+import hs.kr.backend.devpals.domain.tag.dto.SkillTagResponse;
+import hs.kr.backend.devpals.domain.tag.service.TagService;
+import hs.kr.backend.devpals.domain.user.entity.UserEntity;
+import hs.kr.backend.devpals.global.common.ApiResponse;
+import hs.kr.backend.devpals.global.exception.CustomException;
+import hs.kr.backend.devpals.global.exception.ErrorException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ProjectAdminService {
+
+    private final ProjectRepository projectRepository;
+    private final ApplicantRepository applicantRepository;
+    private final TagService tagService;
+    private final FaqAdminService faqAdminService;
+
+    public ResponseEntity<ApiResponse<FullApplicantInfoResponse>> getFullApplicantInfo(Long projectId, Long applicantId, String token) {
+
+        faqAdminService.validateAdmin(token);
+
+        ProjectEntity project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new CustomException(ErrorException.PROJECT_NOT_FOUND));
+
+        List<ApplicantEntity> applicants = applicantRepository.findByProject(project);
+
+        List<ProjectApplicantResponse> applicantResponses = applicants.stream()
+                .map(ProjectApplicantResponse::fromEntity)
+                .collect(Collectors.toList());
+
+        ApplicantEntity targetApplicant = applicantRepository.findById(applicantId)
+                .orElseThrow(() -> new CustomException(ErrorException.USER_NOT_FOUND));
+
+        if (!Objects.equals(targetApplicant.getProject().getId(), projectId)) {
+            throw new CustomException(ErrorException.INVALID_APPLICANT_PROJECT);
+        }
+
+        UserEntity user = targetApplicant.getUser();
+        List<SkillTagResponse> skillResponses = tagService.getSkillTagResponses(project.getSkillTagIds());
+        ProjectApplyDTO detail = ProjectApplyDTO.fromEntity(user, targetApplicant, skillResponses);
+
+        List<ProjectApplicantResultResponse> resultResponses = List.of(
+                ProjectApplicantResultResponse.fromEntity(applicants, tagService)
+        );
+
+        FullApplicantInfoResponse response = FullApplicantInfoResponse.From(applicantResponses, detail, resultResponses);
+        return ResponseEntity.ok(new ApiResponse<>(200, true, "프로젝트 관련 조회 성공 (관리자용)" , response));
+    }
+
+
+}

--- a/src/main/java/hs/kr/backend/devpals/domain/project/service/ProjectApplyService.java
+++ b/src/main/java/hs/kr/backend/devpals/domain/project/service/ProjectApplyService.java
@@ -24,7 +24,7 @@ import java.util.*;
 
 @Service
 @RequiredArgsConstructor
-public class ApplyService {
+public class ProjectApplyService {
 
     private final JwtTokenValidator jwtTokenValidator;
     private final UserRepository userRepository;


### PR DESCRIPTION
1. 관리자용 프로젝트 지원 관련 API를 구현하였습니다.

통합테스트 거친 뒤 Main 브랜치로 병합합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 관리자를 위한 프로젝트 지원자 전체 정보 조회 API가 추가되었습니다. 해당 기능을 통해 특정 프로젝트 및 지원자의 상세 정보, 전체 지원자 목록, 지원 결과를 한 번에 확인할 수 있습니다.

- **리팩터**
  - 프로젝트 지원 관련 컨트롤러 및 서비스의 클래스명이 명확하게 변경되었습니다. (예: ApplyController → ProjectApplyController, ApplyService → ProjectApplyService)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->