### PR TITLE
Dev > Main 브랜치 병합

### DIFF
--- a/src/main/java/hs/kr/backend/devpals/domain/user/controller/UserProfileController.java
+++ b/src/main/java/hs/kr/backend/devpals/domain/user/controller/UserProfileController.java
@@ -150,4 +150,22 @@ public class UserProfileController {
         return userProfileService.getMyInquiries(token);
     }
 
+    @PatchMapping("/github")
+    @Operation(summary = "GitHub URL 수정", description = "본인의 GitHub URL을 수정합니다.")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Github URL 수정 성공")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "400",
+            description = "Github URL 수정 실패",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ApiResponse.class),
+                    examples = @ExampleObject(value = "{\"success\": false, \"message\": \"인증 권한이 없습니다.\", \"data\": null}")
+            )
+    )
+    public ResponseEntity<ApiResponse<String>> updateGithubUrl(
+            @RequestHeader("Authorization") String token,
+            @RequestParam("githubUrl") String githubUrl) {
+        return userProfileService.updateGithub(token, githubUrl);
+    }
+
 }

--- a/src/main/java/hs/kr/backend/devpals/domain/user/service/UserProfileService.java
+++ b/src/main/java/hs/kr/backend/devpals/domain/user/service/UserProfileService.java
@@ -183,6 +183,19 @@ public class UserProfileService {
         return ResponseEntity.ok(new ApiResponse<>(200, true, "작성한 문의글 목록입니다.", inquiryResponses));
     }
 
+    @Transactional
+    public ResponseEntity<ApiResponse<String>> updateGithub(String token, String githubUrl) {
+        Long userId = jwtTokenValidator.getUserId(token);
+
+        UserEntity user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorException.USER_NOT_FOUND));
+
+        user.updateGithub(githubUrl);
+        userRepository.save(user);
+
+        return ResponseEntity.ok(new ApiResponse<>(200, true, "GitHub URL이 업데이트되었습니다.", null));
+    }
+
 
     // 문의글 조회
     public List<InquiryResponse> getMyInquiriesByAdmin(Long userId) {


### PR DESCRIPTION
1. 사용자의 github URL 수정 기능을 구현하였습니다.
통합 테스트 거친 뒤 Main 브랜치로 병합합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 인증된 사용자가 자신의 GitHub URL을 수정할 수 있는 PATCH 엔드포인트가 추가되었습니다.  
- **문서화**
  - 새 엔드포인트에 대한 Swagger/OpenAPI 문서가 추가되어 요청 및 응답 예시와 오류 메시지가 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->